### PR TITLE
Change format of strings exported to sass

### DIFF
--- a/ConfigDistributor.js
+++ b/ConfigDistributor.js
@@ -108,7 +108,8 @@ module.exports = class ConfigDistributor {
     const buildProperties = (carry, pair) => {
       let [key, value] = pair;
       if (typeof value === 'string' && value.indexOf('rgb') !== 0) {
-        value = `#{${value}}`
+        value = value.replace('\'', '"');
+        value = `'${value}'`
       }
 
       if (key.endsWith('_in_px')) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@libero/pattern-library-config-manager",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Configuration manager for Libero patterns",
   "repository": {
     "type": "git",

--- a/test/fixtures/configConsolidationCannedData.js
+++ b/test/fixtures/configConsolidationCannedData.js
@@ -46,7 +46,7 @@ const expectedOutput = {
   sass: {
     sassMap: '$topLevelProperty: (\n'
                + '  nested-number: 100,\n'
-               + '  nested-quoted: #{"Courier 10 Pitch", Courier, monospace},\n'
+               + '  nested-quoted: \'"Courier 10 Pitch", Courier, monospace\',\n'
                + '  nested-color_something: rgb(33, 33, 33),\n'
                + '  basic: 200,\n'
                + ');\n',


### PR DESCRIPTION
To get font stacks defined properly when used in the final sass, a (non-`rgb`) string exported to sass is now transformed by:

1. replacing all single quotes with double quotes
1. wrapping the string in single quotes

